### PR TITLE
Make data types compatible behind different backends

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -28,7 +28,7 @@ bool GetShape(const NodeArg& node_arg, std::vector<int64_t>& shape, const loggin
 }
 
 bool IsNodeSupported(const Node& node, const GraphViewer& graph_viewer,
-                     const WnnDeviceType device_type, const logging::Logger& logger) {
+                     const WebnnDeviceType device_type, const logging::Logger& logger) {
   const auto& op_builders = GetOpBuilders();
   if (Contains(op_builders, node.OpType())) {
     const auto* op_builder = op_builders.at(node.OpType());
@@ -64,7 +64,7 @@ bool IsInputSupported(const NodeArg& input, const std::string& parent_name, cons
 
 std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_viewer,
                                                       const emscripten::val& wnn_builder_,
-                                                      const WnnDeviceType device_type,
+                                                      const WebnnDeviceType device_type,
                                                       const logging::Logger& logger) {
   std::vector<std::vector<size_t>> supported_node_groups;
 
@@ -109,10 +109,10 @@ std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_v
   return supported_node_groups;
 }
 
-bool IsSupportedDataType(const int32_t data_type, const WnnDeviceType device_type) {
+bool IsSupportedDataType(const int32_t data_type, const WebnnDeviceType device_type) {
   // Current data type implementation status of WebNN is inconsistent along with different backends,
   // The XNNPack backend supports only FP32, while the DML backend POC supports more.
-  if (device_type == WnnDeviceType::CPU) {
+  if (device_type == WebnnDeviceType::CPU) {
     return std::find(supported_cpu_data_types.begin(), supported_cpu_data_types.end(), data_type) !=
            supported_cpu_data_types.end();
   } else {

--- a/onnxruntime/core/providers/webnn/builders/helper.cc
+++ b/onnxruntime/core/providers/webnn/builders/helper.cc
@@ -27,11 +27,12 @@ bool GetShape(const NodeArg& node_arg, std::vector<int64_t>& shape, const loggin
   return true;
 }
 
-bool IsNodeSupported(const Node& node, const GraphViewer& graph_viewer, const logging::Logger& logger) {
+bool IsNodeSupported(const Node& node, const GraphViewer& graph_viewer,
+                     const WnnDeviceType device_type, const logging::Logger& logger) {
   const auto& op_builders = GetOpBuilders();
   if (Contains(op_builders, node.OpType())) {
     const auto* op_builder = op_builders.at(node.OpType());
-    return op_builder->IsOpSupported(graph_viewer.GetAllInitializedTensors(), node, logger);
+    return op_builder->IsOpSupported(graph_viewer.GetAllInitializedTensors(), node, device_type, logger);
   } else {
     return false;
   }
@@ -63,6 +64,7 @@ bool IsInputSupported(const NodeArg& input, const std::string& parent_name, cons
 
 std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_viewer,
                                                       const emscripten::val& wnn_builder_,
+                                                      const WnnDeviceType device_type,
                                                       const logging::Logger& logger) {
   std::vector<std::vector<size_t>> supported_node_groups;
 
@@ -82,7 +84,7 @@ std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_v
     // Firstly check if platform supports the WebNN op.
     if (CheckSingleOp(node->OpType(), wnn_builder_)) {
       LOGS(logger, VERBOSE) << "Operator type: [" << node->OpType() << "] is supported by browser";
-      supported = IsNodeSupported(*node, graph_viewer, logger);
+      supported = IsNodeSupported(*node, graph_viewer, device_type, logger);
     }
 
     LOGS(logger, VERBOSE) << "Operator type: [" << node->OpType()
@@ -107,8 +109,16 @@ std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_v
   return supported_node_groups;
 }
 
-bool IsSupportedDataType(int32_t data_type) {
-  return std::find(supported_data_types.begin(), supported_data_types.end(), data_type) != supported_data_types.end();
+bool IsSupportedDataType(const int32_t data_type, const WnnDeviceType device_type) {
+  // Current data type implementation status of WebNN is inconsistent along with different backends,
+  // The XNNPack backend supports only FP32, while the DML backend POC supports more.
+  if (device_type == WnnDeviceType::CPU) {
+    return std::find(supported_cpu_data_types.begin(), supported_cpu_data_types.end(), data_type) !=
+           supported_cpu_data_types.end();
+  } else {
+    return std::find(supported_gpu_data_types.begin(), supported_gpu_data_types.end(), data_type) !=
+           supported_gpu_data_types.end();
+  }
 }
 
 bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -25,7 +25,7 @@ class Logger;
 
 namespace webnn {
 
-enum WnnDeviceType {
+enum class WebnnDeviceType {
   CPU,
   GPU,
 };
@@ -89,7 +89,7 @@ bool IsInputSupported(const NodeArg& node_arg, const std::string& parent_name, c
 // Get a list of groups of supported nodes, each group represents a subgraph supported by WebNN EP.
 std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_viewer,
                                                       const emscripten::val& wnn_builder_,
-                                                      const WnnDeviceType device_type,
+                                                      const WebnnDeviceType device_type,
                                                       const logging::Logger& logger);
 static const InlinedHashMap<std::string, std::string> op_map = {
     {"ArgMax", "argMax"},
@@ -152,7 +152,7 @@ constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 6> supported_gpu_data
     ONNX_NAMESPACE::TensorProto_DataType_UINT32,
 };
 
-bool IsSupportedDataType(const int32_t data_type, const WnnDeviceType device_type);
+bool IsSupportedDataType(const int32_t data_type, const WebnnDeviceType device_type);
 
 bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
                                       std::vector<int64_t>& shape_b,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -25,6 +25,11 @@ class Logger;
 
 namespace webnn {
 
+enum WnnDeviceType {
+  CPU,
+  GPU,
+};
+
 bool GetShape(const NodeArg& node_arg, std::vector<int64_t>& shape, const logging::Logger& logger);
 
 template <typename T>
@@ -84,6 +89,7 @@ bool IsInputSupported(const NodeArg& node_arg, const std::string& parent_name, c
 // Get a list of groups of supported nodes, each group represents a subgraph supported by WebNN EP.
 std::vector<std::vector<NodeIndex>> GetSupportedNodes(const GraphViewer& graph_viewer,
                                                       const emscripten::val& wnn_builder_,
+                                                      const WnnDeviceType device_type,
                                                       const logging::Logger& logger);
 static const InlinedHashMap<std::string, std::string> op_map = {
     {"ArgMax", "argMax"},
@@ -133,7 +139,11 @@ inline bool CheckSingleOp(const std::string& op_type, const emscripten::val& wnn
   return op_map.find(op_type) != op_map.end() && wnn_builder_[op_map.find(op_type)->second].as<bool>();
 }
 
-constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 6> supported_data_types = {
+constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 1> supported_cpu_data_types = {
+    ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
+};
+
+constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 6> supported_gpu_data_types = {
     ONNX_NAMESPACE::TensorProto_DataType_BOOL,
     ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
     ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
@@ -142,7 +152,7 @@ constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 6> supported_data_typ
     ONNX_NAMESPACE::TensorProto_DataType_UINT32,
 };
 
-bool IsSupportedDataType(int32_t data_type);
+bool IsSupportedDataType(const int32_t data_type, const WnnDeviceType device_type);
 
 bool IsValidMultidirectionalBroadcast(std::vector<int64_t>& shape_a,
                                       std::vector<int64_t>& shape_b,

--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -143,13 +143,14 @@ constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 1> supported_cpu_data
     ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
 };
 
-constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 6> supported_gpu_data_types = {
+constexpr std::array<ONNX_NAMESPACE::TensorProto_DataType, 7> supported_gpu_data_types = {
     ONNX_NAMESPACE::TensorProto_DataType_BOOL,
     ONNX_NAMESPACE::TensorProto_DataType_FLOAT16,
     ONNX_NAMESPACE::TensorProto_DataType_FLOAT,
     ONNX_NAMESPACE::TensorProto_DataType_INT32,
     ONNX_NAMESPACE::TensorProto_DataType_INT64,
     ONNX_NAMESPACE::TensorProto_DataType_UINT32,
+    ONNX_NAMESPACE::TensorProto_DataType_UINT64,
 };
 
 bool IsSupportedDataType(const int32_t data_type, const WebnnDeviceType device_type);

--- a/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
@@ -21,7 +21,7 @@ class ArgMaxMinOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -64,7 +64,7 @@ Status ArgMaxMinOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 // Operator support related.
 bool ArgMaxMinOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                            const Node& node,
-                                           WnnDeviceType /* device_type */,
+                                           WebnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/argmax_min_op_builder.cc
@@ -21,7 +21,7 @@ class ArgMaxMinOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -62,7 +62,9 @@ Status ArgMaxMinOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 }
 
 // Operator support related.
-bool ArgMaxMinOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+bool ArgMaxMinOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                           const Node& node,
+                                           WnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -38,7 +38,7 @@ bool HasExternalInitializer(const InitializedTensorSet& initializers, const Node
 Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node& node,
                                         const logging::Logger& logger) const {
   ORT_RETURN_IF_NOT(
-      IsOpSupported(model_builder.GetInitializerTensors(), node, logger),
+      IsOpSupported(model_builder.GetInitializerTensors(), node, model_builder.GetWnnDeviceType(), logger),
       "Unsupported operator ",
       node.OpType());
   ORT_RETURN_IF_ERROR(AddToModelBuilderImpl(model_builder, node, logger));
@@ -50,8 +50,8 @@ Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node&
 // Operator support related.
 
 bool BaseOpBuilder::IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                                  const logging::Logger& logger) const {
-  if (!HasSupportedInputs(node, logger))
+                                  const WnnDeviceType device_type, const logging::Logger& logger) const {
+  if (!HasSupportedInputs(node, device_type, logger))
     return false;
 
   // We do not support external initializers for now.
@@ -61,10 +61,11 @@ bool BaseOpBuilder::IsOpSupported(const InitializedTensorSet& initializers, cons
   if (!HasSupportedOpSet(node, logger))
     return false;
 
-  return IsOpSupportedImpl(initializers, node, logger);
+  return IsOpSupportedImpl(initializers, node, device_type, logger);
 }
 
-bool BaseOpBuilder::HasSupportedInputs(const Node& node, const logging::Logger& logger) const {
+bool BaseOpBuilder::HasSupportedInputs(const Node& node, const WnnDeviceType device_type,
+                                       const logging::Logger& logger) const {
   const auto node_name = MakeString("Node [", node.Name(), "] type [", node.OpType(), "]");
   for (const auto* input : node.InputDefs()) {
     if (!IsInputSupported(*input, node_name, logger)) {
@@ -72,10 +73,12 @@ bool BaseOpBuilder::HasSupportedInputs(const Node& node, const logging::Logger& 
     }
   }
 
-  return HasSupportedInputsImpl(node, logger);
+  return HasSupportedInputsImpl(node, device_type, logger);
 }
 
-bool BaseOpBuilder::HasSupportedInputsImpl(const Node& node, const logging::Logger& logger) const {
+bool BaseOpBuilder::HasSupportedInputsImpl(const Node& node,
+                                           const WnnDeviceType device_type,
+                                           const logging::Logger& logger) const {
   // We only check the type of input 0 by default, specific op builder can override this.
   const auto& input = *node.InputDefs()[0];
 
@@ -83,7 +86,7 @@ bool BaseOpBuilder::HasSupportedInputsImpl(const Node& node, const logging::Logg
   if (!GetType(input, input_type, logger))
     return false;
 
-  if (!IsSupportedDataType(input_type)) {
+  if (!IsSupportedDataType(input_type, device_type)) {
     LOGS(logger, VERBOSE) << "[" << node.OpType()
                           << "] Input type: [" << input_type
                           << "] is not supported for now";

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -38,7 +38,7 @@ bool HasExternalInitializer(const InitializedTensorSet& initializers, const Node
 Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node& node,
                                         const logging::Logger& logger) const {
   ORT_RETURN_IF_NOT(
-      IsOpSupported(model_builder.GetInitializerTensors(), node, model_builder.GetWnnDeviceType(), logger),
+      IsOpSupported(model_builder.GetInitializerTensors(), node, model_builder.GetWebnnDeviceType(), logger),
       "Unsupported operator ",
       node.OpType());
   ORT_RETURN_IF_ERROR(AddToModelBuilderImpl(model_builder, node, logger));
@@ -50,7 +50,7 @@ Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node&
 // Operator support related.
 
 bool BaseOpBuilder::IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                                  const WnnDeviceType device_type, const logging::Logger& logger) const {
+                                  const WebnnDeviceType device_type, const logging::Logger& logger) const {
   if (!HasSupportedInputs(node, device_type, logger))
     return false;
 
@@ -64,7 +64,7 @@ bool BaseOpBuilder::IsOpSupported(const InitializedTensorSet& initializers, cons
   return IsOpSupportedImpl(initializers, node, device_type, logger);
 }
 
-bool BaseOpBuilder::HasSupportedInputs(const Node& node, const WnnDeviceType device_type,
+bool BaseOpBuilder::HasSupportedInputs(const Node& node, const WebnnDeviceType device_type,
                                        const logging::Logger& logger) const {
   const auto node_name = MakeString("Node [", node.Name(), "] type [", node.OpType(), "]");
   for (const auto* input : node.InputDefs()) {
@@ -77,7 +77,7 @@ bool BaseOpBuilder::HasSupportedInputs(const Node& node, const WnnDeviceType dev
 }
 
 bool BaseOpBuilder::HasSupportedInputsImpl(const Node& node,
-                                           const WnnDeviceType device_type,
+                                           const WebnnDeviceType device_type,
                                            const logging::Logger& logger) const {
   // We only check the type of input 0 by default, specific op builder can override this.
   const auto& input = *node.InputDefs()[0];

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.h
@@ -28,22 +28,23 @@ class BaseOpBuilder : public IOpBuilder {
   // Operator support related.
  public:
   bool IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                     const logging::Logger& logger) const override;
+                     const WnnDeviceType device_type, const logging::Logger& logger) const override;
 
  protected:
   virtual bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& /* node */,
-                                 const logging::Logger& /* logger */) const {
+                                 const WnnDeviceType /* device_type */, const logging::Logger& /* logger */) const {
     return true;
   }
 
-  virtual bool HasSupportedInputsImpl(const Node& node, const logging::Logger& logger) const;
+  virtual bool HasSupportedInputsImpl(const Node& node, const WnnDeviceType device_type,
+                                      const logging::Logger& logger) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
   virtual int GetMaxSupportedOpSet(const Node& /* node */) const { return 19; }
 
  private:
   bool HasSupportedOpSet(const Node& node, const logging::Logger& logger) const;
-  bool HasSupportedInputs(const Node& node, const logging::Logger& logger) const;
+  bool HasSupportedInputs(const Node& node, const WnnDeviceType device_type, const logging::Logger& logger) const;
 };
 
 }  // namespace webnn

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.h
@@ -28,15 +28,15 @@ class BaseOpBuilder : public IOpBuilder {
   // Operator support related.
  public:
   bool IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                     const WnnDeviceType device_type, const logging::Logger& logger) const override;
+                     const WebnnDeviceType device_type, const logging::Logger& logger) const override;
 
  protected:
   virtual bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& /* node */,
-                                 const WnnDeviceType /* device_type */, const logging::Logger& /* logger */) const {
+                                 const WebnnDeviceType /* device_type */, const logging::Logger& /* logger */) const {
     return true;
   }
 
-  virtual bool HasSupportedInputsImpl(const Node& node, const WnnDeviceType device_type,
+  virtual bool HasSupportedInputsImpl(const Node& node, const WebnnDeviceType device_type,
                                       const logging::Logger& logger) const;
 
   virtual int GetMinSupportedOpSet(const Node& /* node */) const { return 1; }
@@ -44,7 +44,7 @@ class BaseOpBuilder : public IOpBuilder {
 
  private:
   bool HasSupportedOpSet(const Node& node, const logging::Logger& logger) const;
-  bool HasSupportedInputs(const Node& node, const WnnDeviceType device_type, const logging::Logger& logger) const;
+  bool HasSupportedInputs(const Node& node, const WebnnDeviceType device_type, const logging::Logger& logger) const;
 };
 
 }  // namespace webnn

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -22,7 +22,7 @@ class CastOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType device_type, const logging::Logger& logger) const override;
+                         const WebnnDeviceType device_type, const logging::Logger& logger) const override;
 
   int GetMinSupportedOpSet(const Node& node) const override;
 };
@@ -80,7 +80,7 @@ int CastOpBuilder::GetMinSupportedOpSet(const Node& /* node */) const {
 
 bool CastOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                       const Node& node,
-                                      const WnnDeviceType device_type,
+                                      const WebnnDeviceType device_type,
                                       const logging::Logger& logger) const {
   NodeAttrHelper helper(node);
   // Check cast output type.

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -39,7 +39,7 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   // We already checked the "to" type in IsOpSupportedImpl.
   const auto to_type = helper.Get("to", ONNX_NAMESPACE::TensorProto_DataType_FLOAT);
   std::string operand_type;
-  switch(to_type) {
+  switch (to_type) {
     case ONNX_NAMESPACE::TensorProto_DataType_BOOL:
       operand_type = "uint8";
       break;

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -21,8 +21,8 @@ class CastOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType device_type, const logging::Logger& logger) const override;
 
   int GetMinSupportedOpSet(const Node& node) const override;
 };
@@ -78,14 +78,15 @@ int CastOpBuilder::GetMinSupportedOpSet(const Node& /* node */) const {
   return 6;
 }
 
-bool CastOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool CastOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                      const Node& node,
+                                      const WnnDeviceType device_type,
                                       const logging::Logger& logger) const {
   NodeAttrHelper helper(node);
   // Check cast output type.
   const auto to_type = helper.Get("to", ONNX_NAMESPACE::TensorProto_DataType_UNDEFINED);
-  if (!IsSupportedDataType(to_type)) {
-    LOGS(logger, VERBOSE) << "Invalid cast to type " << to_type
-                          << " . Current WebNN only support cast to bool, float32, float16, int32, int64 or uint32.";
+  if (!IsSupportedDataType(to_type, device_type)) {
+    LOGS(logger, VERBOSE) << "Invalid cast to type " << to_type << ".";
     return false;
   }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/cast_op_builder.cc
@@ -58,6 +58,9 @@ Status CastOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
     case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
       operand_type = "uint32";
       break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      operand_type = "uint64";
+      break;
     default:
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                              "The Cast node has unsupported 'to' type, name: ",

--- a/onnxruntime/core/providers/webnn/builders/impl/clip_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/clip_op_builder.cc
@@ -24,7 +24,7 @@ class ClipOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -66,7 +66,9 @@ Status ClipOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool ClipOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool ClipOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                      const Node& node,
+                                      const WnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   float min, max;
   return GetClipMinMax(initializers, node, min, max, logger);

--- a/onnxruntime/core/providers/webnn/builders/impl/clip_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/clip_op_builder.cc
@@ -24,7 +24,7 @@ class ClipOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -68,7 +68,7 @@ Status ClipOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool ClipOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                       const Node& node,
-                                      const WnnDeviceType /* device_type */,
+                                      const WebnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   float min, max;
   return GetClipMinMax(initializers, node, min, max, logger);

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -140,6 +140,9 @@ Status AddInitializerInNewLayout(ModelBuilder& model_builder,
     case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
       element_size = sizeof(uint32_t);
       break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      element_size = sizeof(uint64_t);
+      break;
     default:
       break;
   }

--- a/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/conv_op_builder.cc
@@ -28,7 +28,7 @@ class ConvOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 void ConvOpBuilder::AddInitializersToSkip(ModelBuilder& model_builder, const Node& node) const {
@@ -96,7 +96,7 @@ Status AddInitializerInNewLayout(ModelBuilder& model_builder,
                                  bool is_conv) {
   const auto& tensor = *model_builder.GetInitializerTensors().at(name);
   auto data_type = tensor.data_type();
-  if (!IsSupportedDataType(data_type, model_builder.GetWnnDeviceType())) {
+  if (!IsSupportedDataType(data_type, model_builder.GetWebnnDeviceType())) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                            "The initializer of graph has unsupported type, name: ",
                            tensor.name(), " type: ", data_type);
@@ -272,7 +272,7 @@ Status ConvOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 bool ConvOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                       const Node& node,
-                                      const WnnDeviceType /* device_type */,
+                                      const WebnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   const auto& name = node.Name();
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
@@ -29,7 +29,7 @@ class ExpandOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -62,7 +62,9 @@ Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool ExpandOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool ExpandOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                        const Node& node,
+                                        const WnnDeviceType /* device_type */,
                                         const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   const auto& shape_name = input_defs[1]->Name();

--- a/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/expand_op_builder.cc
@@ -29,7 +29,7 @@ class ExpandOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -64,7 +64,7 @@ Status ExpandOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool ExpandOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                         const Node& node,
-                                        const WnnDeviceType /* device_type */,
+                                        const WebnnDeviceType /* device_type */,
                                         const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   const auto& shape_name = input_defs[1]->Name();

--- a/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
@@ -21,7 +21,7 @@ class GatherOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -50,7 +50,7 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool GatherOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                         const Node& node,
-                                        const WnnDeviceType /* device_type */,
+                                        const WebnnDeviceType /* device_type */,
                                         const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;

--- a/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gather_op_builder.cc
@@ -20,8 +20,8 @@ class GatherOpBuilder : public BaseOpBuilder {
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
 
   // Operator support related.
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -48,8 +48,10 @@ Status GatherOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool GatherOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                                         const logging::Logger& logger) const {
+bool GatherOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                        const Node& node,
+                                        const WnnDeviceType /* device_type */,
+                                        const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
   if (!GetShape(*input_defs[0], input_shape, logger))

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -24,7 +24,7 @@ class GemmOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -67,7 +67,7 @@ Status GemmOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 bool GemmOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                       const Node& node,
-                                      const WnnDeviceType /* device_type */,
+                                      const WebnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   (void)initializers;
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gemm_op_builder.cc
@@ -23,8 +23,8 @@ class GemmOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& /* node */,
-                         const logging::Logger& /* logger */) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -65,7 +65,9 @@ Status GemmOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const N
 
 // Operator support related.
 
-bool GemmOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool GemmOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                      const Node& node,
+                                      const WnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   (void)initializers;
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
@@ -19,8 +19,8 @@ class LogicalOpBuilder : public BaseOpBuilder {
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
   // Operator support related.
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -57,7 +57,9 @@ void CreateLogicalOpBuilder(const std::string& op_type, OpBuilderRegistrations& 
   }
 }
 
-bool LogicalOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool LogicalOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                         const Node& node,
+                                         const WnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& name = node.Name();
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/logical_op_builder.cc
@@ -20,7 +20,7 @@ class LogicalOpBuilder : public BaseOpBuilder {
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
   // Operator support related.
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -59,7 +59,7 @@ void CreateLogicalOpBuilder(const std::string& op_type, OpBuilderRegistrations& 
 
 bool LogicalOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                          const Node& node,
-                                         const WnnDeviceType /* device_type */,
+                                         const WebnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& name = node.Name();
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -24,7 +24,7 @@ class NormalizationOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -99,7 +99,9 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
 
 // Operator support related.
 
-bool NormalizationOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool NormalizationOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                               const Node& node,
+                                               const WnnDeviceType /* device_type */,
                                                const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   if (input_defs.size() < 2) {

--- a/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/normalization_op_builder.cc
@@ -24,7 +24,7 @@ class NormalizationOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -101,7 +101,7 @@ Status NormalizationOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder
 
 bool NormalizationOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                                const Node& node,
-                                               const WnnDeviceType /* device_type */,
+                                               const WebnnDeviceType /* device_type */,
                                                const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   if (input_defs.size() < 2) {

--- a/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
@@ -24,7 +24,7 @@ class PoolOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -110,7 +110,7 @@ Status PoolOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 // Operator support related.
 bool PoolOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                       const Node& node,
-                                      const WnnDeviceType /* device_type */,
+                                      const WebnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   const auto& op_type = node.OpType();
   const auto& input_defs = node.InputDefs();

--- a/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/pool_op_builder.cc
@@ -23,8 +23,8 @@ class PoolOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -108,7 +108,9 @@ Status PoolOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 }
 
 // Operator support related.
-bool PoolOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+bool PoolOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                      const Node& node,
+                                      const WnnDeviceType /* device_type */,
                                       const logging::Logger& logger) const {
   const auto& op_type = node.OpType();
   const auto& input_defs = node.InputDefs();

--- a/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
@@ -28,8 +28,8 @@ class ReductionOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -106,7 +106,9 @@ Status ReductionOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 }
 
 // Operator support related.
-bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                           const Node& node,
+                                           const WnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reduction_op_builder.cc
@@ -29,7 +29,7 @@ class ReductionOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -108,7 +108,7 @@ Status ReductionOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 // Operator support related.
 bool ReductionOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                            const Node& node,
-                                           const WnnDeviceType /* device_type */,
+                                           const WebnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
@@ -29,7 +29,7 @@ class ReshapeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 
   // Reshape opset 4- uses attributes for new shape which we do not support for now.
   int GetMinSupportedOpSet(const Node& /* node */) const override { return 5; }
@@ -69,7 +69,9 @@ Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                         const Node& node,
+                                         const WnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   const auto& perm_name = input_defs[1]->Name();

--- a/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
@@ -29,7 +29,7 @@ class ReshapeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 
   // Reshape opset 4- uses attributes for new shape which we do not support for now.
   int GetMinSupportedOpSet(const Node& /* node */) const override { return 5; }
@@ -71,7 +71,7 @@ Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool ReshapeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                          const Node& node,
-                                         const WnnDeviceType /* device_type */,
+                                         const WebnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   const auto& perm_name = input_defs[1]->Name();

--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -30,7 +30,7 @@ class ResizeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 
   // Resize opset 10- is very different than Resize opset 11+, with many key attributes missing.
   // We only support Resize opset 11+ here.
@@ -159,7 +159,9 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                        const Node& node,
+                                        const WnnDeviceType /* device_type */,
                                         const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/resize_op_builder.cc
@@ -30,7 +30,7 @@ class ResizeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 
   // Resize opset 10- is very different than Resize opset 11+, with many key attributes missing.
   // We only support Resize opset 11+ here.
@@ -161,7 +161,7 @@ Status ResizeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool ResizeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                         const Node& node,
-                                        const WnnDeviceType /* device_type */,
+                                        const WebnnDeviceType /* device_type */,
                                         const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
 

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -26,7 +26,7 @@ class SliceOpBuilder : public BaseOpBuilder {
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
   // TODO: Support Slice opset < 10, which uses attributes for starts and ends.
   int GetMinSupportedOpSet(const Node& /* node */) const override { return 10; }
 };
@@ -105,7 +105,7 @@ Status SliceOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool SliceOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                        const Node& node,
-                                       const WnnDeviceType /* device_type */,
+                                       const WebnnDeviceType /* device_type */,
                                        const logging::Logger& logger) const {
   const auto& name = node.Name();
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/slice_op_builder.cc
@@ -26,7 +26,7 @@ class SliceOpBuilder : public BaseOpBuilder {
   Status AddToModelBuilderImpl(ModelBuilder& model_builder, const Node& node,
                                const logging::Logger& logger) const override ORT_MUST_USE_RESULT;
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
   // TODO: Support Slice opset < 10, which uses attributes for starts and ends.
   int GetMinSupportedOpSet(const Node& /* node */) const override { return 10; }
 };
@@ -103,7 +103,9 @@ Status SliceOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   return Status::OK();
 }
 
-bool SliceOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool SliceOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                       const Node& node,
+                                       const WnnDeviceType /* device_type */,
                                        const logging::Logger& logger) const {
   const auto& name = node.Name();
   const auto& op_type = node.OpType();

--- a/onnxruntime/core/providers/webnn/builders/impl/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/softmax_op_builder.cc
@@ -21,8 +21,8 @@ class SoftmaxOpBuilder : public BaseOpBuilder {
 
   // Operator support related.
  private:
-  bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+  bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 Status SoftmaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -60,7 +60,9 @@ Status SoftmaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool SoftmaxOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool SoftmaxOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
+                                         const Node& node,
+                                         const WnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;

--- a/onnxruntime/core/providers/webnn/builders/impl/softmax_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/softmax_op_builder.cc
@@ -22,7 +22,7 @@ class SoftmaxOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& /* initializers */, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 Status SoftmaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
@@ -62,7 +62,7 @@ Status SoftmaxOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool SoftmaxOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initializers */,
                                          const Node& node,
-                                         const WnnDeviceType /* device_type */,
+                                         const WebnnDeviceType /* device_type */,
                                          const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;
@@ -82,7 +82,7 @@ bool SoftmaxOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& /* initiali
     return false;
   }
 
-return true;
+  return true;
 }
 
 void CreateSoftmaxOpBuilder(const std::string& op_type, OpBuilderRegistrations& op_registrations) {

--- a/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/split_op_builder.cc
@@ -24,7 +24,7 @@ class SplitOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 
   int GetMinSupportedOpSet(const Node& node) const override;
 };
@@ -110,7 +110,7 @@ int SplitOpBuilder::GetMinSupportedOpSet(const Node& /* node */) const {
 
 bool SplitOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                        const Node& node,
-                                       const WnnDeviceType /* device_type */,
+                                       const WebnnDeviceType /* device_type */,
                                        const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;

--- a/onnxruntime/core/providers/webnn/builders/impl/unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/unsqueeze_op_builder.cc
@@ -28,7 +28,7 @@ class UnsqueezeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
+                         const WebnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -89,7 +89,7 @@ Status UnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
                                            const Node& node,
-                                           const WnnDeviceType /* device_type */,
+                                           const WebnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;

--- a/onnxruntime/core/providers/webnn/builders/impl/unsqueeze_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/unsqueeze_op_builder.cc
@@ -28,7 +28,7 @@ class UnsqueezeOpBuilder : public BaseOpBuilder {
   // Operator support related.
  private:
   bool IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
-                         const logging::Logger& logger) const override;
+                         const WnnDeviceType /* device_type */, const logging::Logger& logger) const override;
 };
 
 // Add operator related.
@@ -87,7 +87,9 @@ Status UnsqueezeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
 
 // Operator support related.
 
-bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers, const Node& node,
+bool UnsqueezeOpBuilder::IsOpSupportedImpl(const InitializedTensorSet& initializers,
+                                           const Node& node,
+                                           const WnnDeviceType /* device_type */,
                                            const logging::Logger& logger) const {
   const auto& input_defs = node.InputDefs();
   std::vector<int64_t> input_shape;

--- a/onnxruntime/core/providers/webnn/builders/model.cc
+++ b/onnxruntime/core/providers/webnn/builders/model.cc
@@ -56,6 +56,10 @@ Status Model::Predict(const InlinedHashMap<std::string, OnnxTensorData>& inputs,
         view = emscripten::val{emscripten::typed_memory_view(num_elements,
                                                              static_cast<const uint32_t*>(tensor.buffer))};
         break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+        view = emscripten::val{emscripten::typed_memory_view(num_elements,
+                                                             static_cast<const uint64_t*>(tensor.buffer))};
+        break;
       default:
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
                                "The input of graph has unsupported type, name: ",
@@ -106,6 +110,10 @@ Status Model::Predict(const InlinedHashMap<std::string, OnnxTensorData>& inputs,
       case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
         view = emscripten::val{emscripten::typed_memory_view(num_elements,
                                                              static_cast<const uint32_t*>(tensor.buffer))};
+        break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+        view = emscripten::val{emscripten::typed_memory_view(num_elements,
+                                                             static_cast<const uint64_t*>(tensor.buffer))};
         break;
       default:
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -171,7 +179,10 @@ void Model::AllocateInputOutputBuffers() {
         wnn_inputs_.set(input, emscripten::val::global("BigInt64Array").new_(num_elements));
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
-        wnn_inputs_.set(input, emscripten::val::global("UInt32Array").new_(num_elements));
+        wnn_inputs_.set(input, emscripten::val::global("Uint32Array").new_(num_elements));
+        break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+        wnn_inputs_.set(input, emscripten::val::global("BigUint64Array").new_(num_elements));
         break;
       default:
         break;
@@ -199,7 +210,10 @@ void Model::AllocateInputOutputBuffers() {
         wnn_outputs_.set(output, emscripten::val::global("BigInt64Array").new_(num_elements));
         break;
       case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
-        wnn_outputs_.set(output, emscripten::val::global("UInt32Array").new_(num_elements));
+        wnn_outputs_.set(output, emscripten::val::global("Uint32Array").new_(num_elements));
+        break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+        wnn_outputs_.set(output, emscripten::val::global("BigUint64Array").new_(num_elements));
         break;
       default:
         break;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -19,12 +19,13 @@ namespace webnn {
 
 ModelBuilder::ModelBuilder(const GraphViewer& graph_viewer, const logging::Logger& logger,
                            const emscripten::val& context, const emscripten::val& builder,
-                           const DataLayout preferred_layout)
+                           const DataLayout preferred_layout, const WnnDeviceType wnn_device_type)
     : graph_viewer_(graph_viewer),
       logger_(logger),
       wnn_context_(context),
       wnn_builder_(builder),
-      preferred_layout_(preferred_layout) {}
+      preferred_layout_(preferred_layout),
+      wnn_device_type_(wnn_device_type) {}
 
 Status ModelBuilder::Initialize() {
   PreprocessInitializers();
@@ -106,7 +107,7 @@ Status ModelBuilder::RegisterInitializers() {
     desc.set("dimensions", emscripten::val::array(dims));
     auto data_type = tensor.data_type();
     emscripten::val operand = emscripten::val::object();
-    if (IsSupportedDataType(data_type)) {
+    if (IsSupportedDataType(data_type, wnn_device_type_)) {
       unpacked_tensors_.push_back({});
       std::vector<uint8_t>& unpacked_tensor = unpacked_tensors_.back();
       ORT_RETURN_IF_ERROR(onnxruntime::utils::UnpackInitializerData(tensor, unpacked_tensor));

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -144,6 +144,11 @@ Status ModelBuilder::RegisterInitializers() {
           view = emscripten::val{emscripten::typed_memory_view(num_elements,
                                                                reinterpret_cast<uint32_t*>(unpacked_tensor.data()))};
           break;
+        case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+          desc.set("type", emscripten::val("uint64"));
+          view = emscripten::val{emscripten::typed_memory_view(num_elements,
+                                                               reinterpret_cast<uint64_t*>(unpacked_tensor.data()))};
+          break;
         default:
           break;
       }
@@ -241,6 +246,9 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
       case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
         desc.set("type", emscripten::val("uint32"));
         break;
+      case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+        desc.set("type", emscripten::val("uint64"));
+        break;
       default: {
         // TODO: support other type.
         return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
@@ -327,6 +335,11 @@ Status ModelBuilder::AddOperandFromPersistMemoryBuffer(
       view = emscripten::val{emscripten::typed_memory_view(size / sizeof(uint32_t),
                                                            reinterpret_cast<const uint32_t*>(dest))};
       desc.set("type", emscripten::val("uint32"));
+      break;
+    case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
+      view = emscripten::val{emscripten::typed_memory_view(size / sizeof(uint64_t),
+                                                           reinterpret_cast<const uint64_t*>(dest))};
+      desc.set("type", emscripten::val("uint64"));
       break;
     default:
       break;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -19,7 +19,7 @@ namespace webnn {
 
 ModelBuilder::ModelBuilder(const GraphViewer& graph_viewer, const logging::Logger& logger,
                            const emscripten::val& context, const emscripten::val& builder,
-                           const DataLayout preferred_layout, const WnnDeviceType wnn_device_type)
+                           const DataLayout preferred_layout, const WebnnDeviceType wnn_device_type)
     : graph_viewer_(graph_viewer),
       logger_(logger),
       wnn_context_(context),

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -9,6 +9,7 @@
 
 #include "model.h"
 #include "core/framework/execution_provider.h"
+#include "core/providers/webnn/builders/helper.h"
 
 #include <emscripten.h>
 #include <emscripten/val.h>
@@ -20,8 +21,9 @@ class IOpBuilder;
 
 class ModelBuilder {
  public:
-  ModelBuilder(const GraphViewer& graph_viewer, const logging::Logger& logger, const emscripten::val& context,
-               const emscripten::val& builder, const DataLayout preferred_layout);
+  ModelBuilder(const GraphViewer& graph_viewer, const logging::Logger& logger,
+               const emscripten::val& context, const emscripten::val& builder,
+               const DataLayout preferred_layout, const WnnDeviceType wnn_device_type);
   ~ModelBuilder() = default;
 
   Status Compile(std::unique_ptr<Model>& model) ORT_MUST_USE_RESULT;
@@ -50,6 +52,8 @@ class ModelBuilder {
 
   DataLayout GetPreferredLayout() const { return preferred_layout_; }
 
+  WnnDeviceType GetWnnDeviceType() const { return wnn_device_type_; }
+
   // The initializer will be processed separately, skip it as an initializer.
   void AddInitializerToSkip(const std::string& tensor_name);
 
@@ -66,6 +70,7 @@ class ModelBuilder {
   emscripten::val wnn_context_ = emscripten::val::object();
   emscripten::val wnn_builder_ = emscripten::val::object();
   DataLayout preferred_layout_;
+  WnnDeviceType wnn_device_type_;
   std::vector<std::vector<uint8_t>> unpacked_tensors_;
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -23,7 +23,7 @@ class ModelBuilder {
  public:
   ModelBuilder(const GraphViewer& graph_viewer, const logging::Logger& logger,
                const emscripten::val& context, const emscripten::val& builder,
-               const DataLayout preferred_layout, const WnnDeviceType wnn_device_type);
+               const DataLayout preferred_layout, const WebnnDeviceType wnn_device_type);
   ~ModelBuilder() = default;
 
   Status Compile(std::unique_ptr<Model>& model) ORT_MUST_USE_RESULT;
@@ -52,7 +52,7 @@ class ModelBuilder {
 
   DataLayout GetPreferredLayout() const { return preferred_layout_; }
 
-  WnnDeviceType GetWnnDeviceType() const { return wnn_device_type_; }
+  WebnnDeviceType GetWebnnDeviceType() const { return wnn_device_type_; }
 
   // The initializer will be processed separately, skip it as an initializer.
   void AddInitializerToSkip(const std::string& tensor_name);
@@ -70,7 +70,7 @@ class ModelBuilder {
   emscripten::val wnn_context_ = emscripten::val::object();
   emscripten::val wnn_builder_ = emscripten::val::object();
   DataLayout preferred_layout_;
-  WnnDeviceType wnn_device_type_;
+  WebnnDeviceType wnn_device_type_;
   std::vector<std::vector<uint8_t>> unpacked_tensors_;
   InlinedHashMap<std::string, emscripten::val> wnn_operands_;
   std::vector<std::string> input_names_;

--- a/onnxruntime/core/providers/webnn/builders/op_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/op_builder.h
@@ -29,7 +29,7 @@ class IOpBuilder {
  public:
   // Check if an operator is supported.
   virtual bool IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                             const WnnDeviceType device_type, const logging::Logger& logger) const = 0;
+                             const WebnnDeviceType device_type, const logging::Logger& logger) const = 0;
 };
 
 }  // namespace webnn

--- a/onnxruntime/core/providers/webnn/builders/op_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/op_builder.h
@@ -2,6 +2,8 @@
 // Copyright (c) Intel Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "core/providers/webnn/builders/helper.h"
+
 #pragma once
 
 namespace onnxruntime {
@@ -27,7 +29,7 @@ class IOpBuilder {
  public:
   // Check if an operator is supported.
   virtual bool IsOpSupported(const InitializedTensorSet& initializers, const Node& node,
-                             const logging::Logger& logger) const = 0;
+                             const WnnDeviceType device_type, const logging::Logger& logger) const = 0;
 };
 
 }  // namespace webnn

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
@@ -52,8 +52,10 @@ WebNNExecutionProvider::WebNNExecutionProvider(
   // WebNN EP uses NHWC layout for CPU XNNPACK backend and NCHW for GPU DML backend.
   if (webnn_device_flags.compare("cpu") == 0) {
     preferred_layout_ = DataLayout::NHWC;
+    wnn_device_type_ = webnn::WnnDeviceType::CPU;
   } else {
     preferred_layout_ = DataLayout::NCHW;
+    wnn_device_type_ = webnn::WnnDeviceType::GPU;
   }
   if (webnn_power_flags.compare("default") != 0) {
     context_options.set("powerPreference", emscripten::val(webnn_power_flags));
@@ -100,7 +102,7 @@ WebNNExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_view
 
   const auto& logger = *GetLogger();
 
-  const auto node_groups = webnn::GetSupportedNodes(graph_viewer, wnn_builder_, logger);
+  const auto node_groups = webnn::GetSupportedNodes(graph_viewer, wnn_builder_, wnn_device_type_, logger);
 
   if (node_groups.empty()) {
     return result;
@@ -218,7 +220,8 @@ common::Status WebNNExecutionProvider::Compile(const std::vector<FusedNodeAndGra
     Node& fused_node = fused_node_and_graph.fused_node;
     const onnxruntime::GraphViewer& graph_viewer(fused_node_and_graph.filtered_graph);
 
-    webnn::ModelBuilder builder(graph_viewer, *GetLogger(), wnn_context_, wnn_builder_, preferred_layout_);
+    webnn::ModelBuilder builder(graph_viewer, *GetLogger(), wnn_context_,
+                                wnn_builder_, preferred_layout_, wnn_device_type_);
     std::unique_ptr<webnn::Model> model;
     ORT_RETURN_IF_ERROR(builder.Compile(model));
     // Build map from input name to its index in input definitions.

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
@@ -325,6 +325,7 @@ common::Status WebNNExecutionProvider::Compile(const std::vector<FusedNodeAndGra
             case ONNX_NAMESPACE::TensorProto_DataType_INT32:
             case ONNX_NAMESPACE::TensorProto_DataType_INT64:
             case ONNX_NAMESPACE::TensorProto_DataType_UINT32:
+            case ONNX_NAMESPACE::TensorProto_DataType_UINT64:
               output_buffer = output_tensor.GetTensorMutableRawData();
               break;
             default:

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.cc
@@ -52,10 +52,10 @@ WebNNExecutionProvider::WebNNExecutionProvider(
   // WebNN EP uses NHWC layout for CPU XNNPACK backend and NCHW for GPU DML backend.
   if (webnn_device_flags.compare("cpu") == 0) {
     preferred_layout_ = DataLayout::NHWC;
-    wnn_device_type_ = webnn::WnnDeviceType::CPU;
+    wnn_device_type_ = webnn::WebnnDeviceType::CPU;
   } else {
     preferred_layout_ = DataLayout::NCHW;
-    wnn_device_type_ = webnn::WnnDeviceType::GPU;
+    wnn_device_type_ = webnn::WebnnDeviceType::GPU;
   }
   if (webnn_power_flags.compare("default") != 0) {
     context_options.set("powerPreference", emscripten::val(webnn_power_flags));

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.h
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.h
@@ -6,6 +6,7 @@
 
 #include "core/common/inlined_containers.h"
 #include "core/framework/execution_provider.h"
+#include "core/providers/webnn/builders/helper.h"
 
 #include <emscripten.h>
 #include <emscripten/val.h>
@@ -44,6 +45,7 @@ class WebNNExecutionProvider : public IExecutionProvider {
   emscripten::val wnn_builder_ = emscripten::val::object();
 
   DataLayout preferred_layout_;
+  webnn::WnnDeviceType wnn_device_type_;
   InlinedHashMap<std::string, std::unique_ptr<onnxruntime::webnn::Model>> models_;
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/webnn_execution_provider.h
+++ b/onnxruntime/core/providers/webnn/webnn_execution_provider.h
@@ -45,7 +45,7 @@ class WebNNExecutionProvider : public IExecutionProvider {
   emscripten::val wnn_builder_ = emscripten::val::object();
 
   DataLayout preferred_layout_;
-  webnn::WnnDeviceType wnn_device_type_;
+  webnn::WebnnDeviceType wnn_device_type_;
   InlinedHashMap<std::string, std::unique_ptr<onnxruntime::webnn::Model>> models_;
 };
 }  // namespace onnxruntime


### PR DESCRIPTION
Current data type implementation status is inconsistent along with different backends, introduce new device_type parameter to distinguish different data type support status.
