### PR TITLE
[WebNN] Fix GRU linear_before_reset trailing space typo

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/gru_op_builder.cc
@@ -72,7 +72,7 @@ Status GruOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder, const No
     options.set("initialHiddenState", model_builder.GetOperand(input_defs[5]->Name()));
   }
 
-  bool linear_before_reset = !!helper.Get("linear_before_reset ", 0);
+  bool linear_before_reset = !!helper.Get("linear_before_reset", 0);
   options.set("resetAfter", linear_before_reset);
 
   const auto& output_defs = node.OutputDefs();


### PR DESCRIPTION
### Issue

Line 75 of gru_op_builder.cc looks up the ONNX GRU attribute with a trailing space in the name:


`helper.Get("linear_before_reset ", 0)`

"linear_before_reset " never matches the actual ONNX attribute "linear_before_reset", so the lookup always fails and resetAfter silently defaults to false — regardless of what the model specifies.

### Impact
Any GRU node with linear_before_reset=1 produces incorrect output on the WebNN execution provider with no error or warning. Affected models include DeepFilterNet3, which has 5 GRU nodes all with linear_before_reset=1. On WebNN-GPU and WebNN-NPU these produce significantly wrong results compared to the WASM reference.

